### PR TITLE
Uniform Bitte Key Name

### DIFF
--- a/src/services/plugin-service.ts
+++ b/src/services/plugin-service.ts
@@ -2,15 +2,15 @@ import { BASE_URL } from '../config/constants';
 import type { KeySignMessageParams } from '../utils/verify-msg-utils';
 import { getAuthentication, getSignedMessage } from './signer-service';
 
-export async function registerPlugin(pluginId: string, bitteKey?: string): Promise<string | null> {
+export async function registerPlugin(pluginId: string, bitteKeyString?: string): Promise<string | null> {
 
-    if (!bitteKey) {
+    if (!bitteKeyString) {
         const signedMessage = await getSignedMessage();
-        bitteKey = JSON.stringify(signedMessage);
+        bitteKeyString = JSON.stringify(signedMessage);
     }
 
     try {
-        const response = await fetch(`${BASE_URL}/${pluginId}`, { method: 'POST', headers: { 'bitte-api-key': bitteKey } });
+        const response = await fetch(`${BASE_URL}/${pluginId}`, { method: 'POST', headers: { 'bitte-api-key': bitteKeyString } });
         if (response.ok) {
             await response.json();
             console.log(`Plugin registered successfully`);
@@ -30,16 +30,16 @@ export async function registerPlugin(pluginId: string, bitteKey?: string): Promi
 }
 
 export async function updatePlugin(pluginId: string, accountId: string | undefined): Promise<void> {
-    const message = await getAuthentication(accountId)
+    const bitteKeyString = await getAuthentication(accountId)
 
-    if (!message) {
+    if (!bitteKeyString) {
         console.error(`No API key found for plugin ${pluginId}. Please register the plugin first.`);
         return;
     }
 
     const response = await fetch(`${BASE_URL}/${pluginId}`, {
         method: 'PUT',
-        headers: { 'bitte-api-key': message },
+        headers: { 'bitte-api-key': bitteKeyString },
     });
     if (response.ok) {
         console.log("Plugin updated successfully.");

--- a/src/services/plugin-service.ts
+++ b/src/services/plugin-service.ts
@@ -1,5 +1,4 @@
 import { BASE_URL } from '../config/constants';
-import type { KeySignMessageParams } from '../utils/verify-msg-utils';
 import { getAuthentication, getSignedMessage } from './signer-service';
 
 export async function registerPlugin(pluginId: string, bitteKeyString?: string): Promise<string | null> {

--- a/src/services/tunnel-service.ts
+++ b/src/services/tunnel-service.ts
@@ -72,7 +72,7 @@ async function setupAndValidate(tunnelUrl: string, pluginId: string): Promise<vo
 
     const specUrl = getSpecUrl(tunnelUrl);
 
-    console.log("Validating OpenAPI spec...");
+    console.log(`Validating OpenAPI spec at ${specUrl}...`);
     const { isValid, accountId } = await validateAndParseOpenApiSpec(specUrl);
 
     if (!isValid) {


### PR DESCRIPTION
Just making the same name used for all `bitte-api-key` headers (easier to read).

Used `bitteKeyString`, however we could also use `bitteKey` everywhere (although it is a stringified object).