### PR TITLE
Write `bitte.dev.json` contents to `.env` instead

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,3 +10,5 @@ export const SIGN_MESSAGE_PORT = 6969;
 export const SIGN_MESSAGE_URL = "https://wallet.bitte.ai/sign-message";
 export const SIGN_MESSAGE_SUCCESS_URL = "https://wallet.bitte.ai/success";
 export const SIGN_MESSAGE = "Register Bitte Agent!"
+export const BITTE_CONFIG_ENV_KEY = "BITTE_CONFIG"
+export const BITTE_KEY_ENV_KEY = "BITTE_KEY"

--- a/src/services/signer-service.ts
+++ b/src/services/signer-service.ts
@@ -8,6 +8,7 @@ import {
   type KeySignMessageParams,
 } from "../utils/verify-msg-utils";
 import {
+  BITTE_KEY_ENV_KEY,
   SIGN_MESSAGE,
   SIGN_MESSAGE_PORT,
   SIGN_MESSAGE_SUCCESS_URL,
@@ -71,7 +72,7 @@ async function createAndStoreKey(): Promise<KeySignMessageParams | null> {
       console.warn("Message verification failed");
     }
 
-    await appendToEnv("BITTE_KEY", JSON.stringify(signedMessage));
+    await appendToEnv(BITTE_KEY_ENV_KEY, JSON.stringify(signedMessage));
     return signedMessage;
   } catch (error) {
     console.error("Error creating and storing key:", error);

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -13,11 +13,17 @@ export function writeFile(filePath: string, content: string): void {
     writeFileSync(filePath, content);
 }
 
+const ENV_FILES = ['.env', '.env.local', '.env.development', '.env.production'];
 export async function appendToEnv(key: string, value: string): Promise<void> {
-    const envFiles = ['.env', '.env.local', '.env.development', '.env.production'];
-    const envEntry = `${key}=${value}`;
-    
-    let envPath = envFiles.find(file => existsSync(file));
+    // clean up any previous insertion
+    removeFromEnv(key);
+
+    // make sure the value is in a single line (easier to remove)
+    const formattedValue = value.replace(/\n/g, '');
+
+    const envEntry = `${key}=${formattedValue}`;
+
+    let envPath = ENV_FILES.find(file => existsSync(file));
 
     if (envPath) {
         appendFileSync(envPath, `\n${envEntry}`);
@@ -26,6 +32,32 @@ export async function appendToEnv(key: string, value: string): Promise<void> {
         writeFileSync(envPath, envEntry);
     }
 
+    dotenv.config();
+    dotenv.config({ path: `.env.local`, override: true });
+}
+
+
+
+
+export async function removeFromEnv(key: string): Promise<void> {
+    for (const envPath of ENV_FILES) {
+        if (existsSync(envPath)) {
+            let envContent = readFileSync(envPath, 'utf-8');
+            const regex = new RegExp(`^${key}=.*\n?`, 'gm');
+            
+            let updatedContent = envContent.replace(regex, '');
+            
+            // Remove empty lines
+            updatedContent = updatedContent.replace(/^\s*[\r\n]|[\r\n]+$/gm, '');
+
+            if (updatedContent !== envContent) {
+                writeFileSync(envPath, updatedContent);
+                console.log(`Removed ${key} from ${envPath}`);
+            }
+        }
+    }
+
+    // Reload environment variables
     dotenv.config();
     dotenv.config({ path: `.env.local`, override: true });
 }


### PR DESCRIPTION
This will deprecate the usage of `bitte.dev.json` so projects that  use `bitte.dev.json` will need to update their code before updating make-dev

[Asana task](https://app.asana.com/0/1208558378933917/1208559777147218/f)