### PR TITLE
Autodetect port on current working directory

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,10 +1,20 @@
 import { Command } from "commander";
 import { startLocalTunnelAndRegister } from "../services/tunnel-service";
+import { detectPort } from "../utils/port-detector";
 
 export const devCommand = new Command()
     .name('dev')
     .description('Make your AI agent discoverable and register the plugin')
-    .requiredOption('-p, --port <number>', 'Local port to expose', parseInt)
+    .option('-p, --port <number>', 'Local port to expose', parseInt)
     .action(async (options) => {
-        await startLocalTunnelAndRegister(options.port);
+        let port = options.port;
+        if (!port) {
+            port = await detectPort();
+            if (!port) {
+                console.error('Unable to detect the port automatically. Please specify a port using the -p or --port option.');
+                process.exit(1);
+            }
+            console.log(`Detected port: ${port}`);
+        }
+        await startLocalTunnelAndRegister(port);
     });

--- a/src/services/tunnel-service.ts
+++ b/src/services/tunnel-service.ts
@@ -122,7 +122,7 @@ async function setupTunnel(port: number): Promise<{ tunnelUrl: string; cleanup: 
 }
 
 export async function startLocalTunnelAndRegister(port: number): Promise<void> {
-    console.log("Setting up local tunnel...");
+    console.log(`Setting up local tunnel on port ${port}...`);
     const { tunnelUrl, cleanup } = await setupTunnel(port);
 
     const pluginId = new URL(tunnelUrl).hostname;

--- a/src/utils/port-detector.ts
+++ b/src/utils/port-detector.ts
@@ -1,0 +1,55 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export async function detectPort(): Promise<number | null> {
+  try {
+    // For Unix-like systems (Linux, macOS)
+    // Get PIDs of Node processes running in the current directory
+    const { stdout: pidOutput } = await execAsync(`lsof -n | grep '${process.cwd()}' | grep node | awk '{print $2}' | uniq`);
+    const pids = pidOutput.trim().split('\n');
+
+    if (pids.length === 0) {
+      console.log('No Node.js processes found running in the current directory.');
+      return null;
+    }
+
+    // Get ports for all node processes
+    const { stdout: portOutput } = await execAsync(`lsof -n -i -P | grep LISTEN | grep node`);
+    const portLines = portOutput.trim().split('\n');
+    
+    // Filter port lines by pid and then extract ports
+    const ports = portLines
+      .filter(line => pids.some(pid => line.includes(pid)))
+      .map(line => {
+        const match = line.match(/:(\d+)/);
+        return match ? parseInt(match[1], 10) : null;
+      })
+      .filter((port): port is number => port !== null);
+
+    if (ports.length === 0) {
+      console.log('No ports found for Node.js processes in the current directory.');
+      return null;
+    }
+
+    if (ports.length > 1) {
+      console.log(`Multiple ports found: ${ports.join(', ')}. Using the first one.`);
+    }
+
+    return ports[0];
+  } catch (error) {
+    // If lsof fails, it might be a Windows system or lsof is not installed
+    try {
+      // For Windows
+      const { stdout } = await execAsync("netstat -ano | findstr :LISTENING | findstr node.exe");
+      const match = stdout.match(/:(\d+)/);
+      if (match && match[1]) {
+        return parseInt(match[1], 10);
+      }
+    } catch (winError) {
+      console.error('Error detecting port:', winError);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
If the user is running a node project on the directory where make-agent is called, we can now automatically detect the port used by that project and use it