### PR TITLE
feat: add a `new` command to create a boilerplate project

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/bun": "latest",
+    "@types/commander": "^2.12.5",
     "@types/inquirer": "^9.0.7",
     "@types/localtunnel": "^2.0.4",
     "@types/node": "^22.7.2",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,0 +1,40 @@
+import { Command } from "commander";
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import * as path from "path";
+import type { ExecSyncOptions } from "child_process";
+
+export const newCommand = new Command()
+  .name("new")
+  .description("Create a new AI agent from the boilerplate")
+  .argument("[name]", "Name of the agent directory")
+  .action(async (name: string | undefined) => {
+    const repoUrl = "https://github.com/BitteProtocol/agent-next-boilerplate.git";
+    const dirName = name || "agent-next-boilerplate";
+    
+    // Check if directory already exists
+    if (existsSync(dirName)) {
+      console.error(`Error: Directory '${dirName}' already exists`);
+      process.exit(1);
+    }
+
+    try {
+      console.log(`Creating new agent in directory: ${dirName}`);
+      console.log("Cloning boilerplate repository...");
+      
+      const execOptions: ExecSyncOptions = { stdio: "inherit" };
+      execSync(`git clone ${repoUrl} ${dirName}`, execOptions);
+      
+      // Remove the .git directory to start fresh
+      execSync(`rm -rf ${path.join(dirName, ".git")}`, execOptions);
+      
+      console.log("\nSuccess! Created new agent at", path.resolve(dirName));
+      console.log("\nNext steps:");
+      console.log(`  cd ${dirName}`);
+      console.log("  npm install");
+      console.log("  npm run dev");
+    } catch (error: unknown) {
+      console.error("Failed to create new agent:", error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { devCommand } from "./commands/dev";
 import { registerCommand } from "./commands/register";
 import { updateCommand } from "./commands/update";
 import { verifyCommand } from "./commands/verify";
+import { newCommand } from "./commands/new";
 
 dotenv.config();
 
@@ -25,6 +26,7 @@ program
   .addCommand(registerCommand)
   .addCommand(updateCommand)
   .addCommand(deleteCommand)
-  .addCommand(verifyCommand);
+  .addCommand(verifyCommand)
+  .addCommand(newCommand);
 
 program.parse();


### PR DESCRIPTION
You can now use make-agent to create a new project with the boilercode template.
Use:
- `make-agent new my-test-agent` with a custom name. 
- `make-agent new` for a default repo name. 