### PR TITLE
Merge `register` and `update` commands into `deploy`

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -34,18 +34,15 @@ export const deployCommand = new Command()
     }
     const pluginService = new PluginService();
     try {
-      await pluginService.update(id, accountId);
-      console.log(`Plugin ${id} updated successfully.`);
-    } catch (error) {
-      console.log("Plugin not found. Attempting to register...");
-      const result = await pluginService.register({
-        pluginId: id,
-        accountId,
-      });
-      if (result) {
-        console.log(`Plugin ${id} registered successfully.`);
-      } else {
-        console.error("Plugin registration failed.");
+      const updateRes = await pluginService.update(id, accountId);
+      if (!updateRes) {
+        console.log("Attempting to register plugin...");
+        await pluginService.register({
+          pluginId: id,
+          accountId,
+        });
       }
+    } catch (error) {
+      console.error(`Failed to deploy plugin ${id}. Error: ${error}`);
     }
   });

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -1,43 +1,10 @@
 import { Command } from "commander";
 
-import { PluginService } from "../services/plugin";
-import { deployedUrl } from "../utils/deployed-url";
-import { validateAndParseOpenApiSpec } from "../utils/openapi";
-import { getHostname, getSpecUrl } from "../utils/url-utils";
-
 export const registerCommand = new Command()
   .name("register")
-  .description("Register a new plugin with a URL")
-  .option("-u, --url <url>", "Specify the deployment URL")
-  .action(async (options) => {
-    const url = options.url || deployedUrl;
-
-    if (!url) {
-      console.error("Deployed URL could not be determined.");
-      return;
-    }
-
-    const pluginId = getHostname(url);
-    const specUrl = getSpecUrl(url);
-    const { isValid, accountId } = await validateAndParseOpenApiSpec(specUrl);
-
-    if (!isValid) {
-      console.error("OpenAPI specification validation failed.");
-      return;
-    }
-
-    if (!accountId) {
-      console.error("Failed to parse account ID from OpenAPI specification.");
-      return;
-    }
-
-    const result = await new PluginService().register({
-      pluginId,
-      accountId,
-    });
-    if (result) {
-      console.log(`Plugin ${pluginId} registered successfully.`);
-    } else {
-      console.error("Plugin registration failed.");
-    }
+  .description("(Deprecated)")
+  .action(async () => {
+    console.log(
+      "The 'register' command has been deprecated. Use 'deploy' instead.",
+    );
   });

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,47 +1,10 @@
 import { Command } from "commander";
 
-import { PluginService } from "../services/plugin";
-import { deployedUrl } from "../utils/deployed-url";
-import { validateAndParseOpenApiSpec } from "../utils/openapi";
-import { getSpecUrl, getHostname } from "../utils/url-utils";
-
 export const updateCommand = new Command()
   .name("update")
-  .description("Update an existing AI agent plugin")
-  .option("-u, --url <url>", "Specify the deployment URL")
-  .action(async (options) => {
-    const url = options.url || deployedUrl;
-
-    if (!url) {
-      console.error("Deployed URL could not be determined.");
-      return;
-    }
-
-    const pluginId = getHostname(url);
-    const specUrl = getSpecUrl(url);
-    const { isValid, accountId } = await validateAndParseOpenApiSpec(specUrl);
-
-    if (!isValid) {
-      console.error("OpenAPI specification validation failed.");
-      return;
-    }
-
-    if (!accountId) {
-      console.error("Failed to parse account ID from OpenAPI specification.");
-      return;
-    }
-    const pluginService = new PluginService();
-    const authentication =
-      await pluginService.auth.getAuthentication(accountId);
-    if (!authentication) {
-      console.error("Authentication failed. Unable to update the plugin.");
-      return;
-    }
-
-    try {
-      await pluginService.update(pluginId, accountId);
-      console.log(`Plugin ${pluginId} updated successfully.`);
-    } catch (error) {
-      console.error("Failed to update the plugin:", error);
-    }
+  .description("(Deprecated)")
+  .action(async () => {
+    console.log(
+      "The 'update' command has been deprecated. Use 'deploy' instead.",
+    );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,9 @@ program
   .addCommand(devCommand)
   .addCommand(deployCommand)
   .addCommand(contractCommand)
-  .addCommand(registerCommand)
-  .addCommand(updateCommand)
   .addCommand(deleteCommand)
-  .addCommand(verifyCommand);
+  .addCommand(verifyCommand)
+  .addCommand(registerCommand)
+  .addCommand(updateCommand);
 
 program.parse();

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -49,14 +49,12 @@ export class PluginService {
     }
   }
 
-  async update(pluginId: string, accountId?: string): Promise<void> {
+  async update(pluginId: string, accountId?: string): Promise<string | null> {
     const message = await this.auth.getAuthentication(accountId);
 
     if (!message) {
-      console.error(
-        `No API key found for plugin ${pluginId}. Please register the plugin first.`,
-      );
-      return;
+      console.warn(`No API key found for plugin ${pluginId}.`);
+      return null;
     }
 
     const response = await fetch(`${this.bitteUrls.BASE_URL}/${pluginId}`, {
@@ -64,11 +62,13 @@ export class PluginService {
       headers: { "bitte-api-key": message },
     });
 
-    if (response.ok) {
-      console.log("Plugin updated successfully.");
-    } else {
-      console.error(`Error updating plugin: ${await response.text()}`);
+    if (!response.ok) {
+      console.error(`Failed to update plugin: ${await response.text()}`);
+      return null;
     }
+
+    console.log("Plugin updated successfully.");
+    return pluginId;
   }
 
   async delete(pluginId: string): Promise<void> {


### PR DESCRIPTION
The `register` > `deploy` > `update` command flow was a bit unintuitive so now `deploy` can do all their functions which should be easier to understand.