### PR TITLE
Support verify data in x mb

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,11 @@ Currently, the CLI supports the following command:
    ```
 
    Options:
-
-   - `-p, --port <number>`: Specify the local port to expose (optional). \\
+   - `-p, --port <number>`: Specify the local port to expose (optional).
 
    If no port is provided, the command will search for a node instance running in the current directory and assume its port.
 
-2. ### **`deploy`**: Deploy your AI agent, making it discoverable and registering it as a plugin
+1. ### **`deploy`**: Register or update your AI agent, making it discoverable as a plugin
 
    Usage:
 
@@ -41,41 +40,11 @@ Currently, the CLI supports the following command:
    ```
 
    Options:
+   - `-u, --url <url>`: The URL where your agent is hosted (optional)
 
-   - `-u, --url <url>`: Specify the deployment URL (optional)
+   If no URL is provided, the command will attempt to determine the URL automatically through environment variables.
 
-   If no URL is provided, the command will attempt to determine the deployed URL automatically.
-
-3. ### **`register`**: Register a new plugin with a URL
-
-   Usage:
-
-   ```bash
-   npx make-agent register [options]
-   ```
-
-   Options:
-
-   - `-u, --url <url>`: Specify the deployment URL (optional)
-
-   If no URL is provided, the command will attempt to determine the deployed URL automatically.
-
-4. ### **`update`**: Update an existing AI agent plugin
-
-   Usage:
-
-   ```bash
-   npx make-agent update [options]
-   ```
-
-   Options:
-
-   - `-u, --url <url>`: Specify the deployment URL (optional)
-
-   If no URL is provided, the command will attempt to determine the deployed URL automatically.
-
-5. ### **`contract`**: Scaffold a basic agent from a NEAR contract that has an ABI
-
+1. ### **`contract`**: Scaffold a basic agent from a NEAR contract that has an ABI
    Usage:
 
    ```bash
@@ -84,7 +53,7 @@ Currently, the CLI supports the following command:
 
    You will be prompted to select a contractId, add a description with instructions on how the agent should use the contract and an output directory
 
-6. ### **`delete`**: Delete your AI agent plugin
+1. ### **`delete`**: Delete your AI agent plugin
 
    Usage:
 
@@ -98,12 +67,12 @@ Currently, the CLI supports the following command:
 
    If no URL is provided, the command will attempt to determine the deployed URL automatically.
 
-7. ### **`verify`**: Request your plugin's verification
+1. ### **`verify`**: Request your plugin's verification
 
    Usage:
 
    ```bash
-   npx make-agent verify -u <url> -e <email> -r <repoUrl> -v <versionNumber>
+   npx make-agent verify -u <url> -e <email> -r <repoUrl> -v <versionNumber> -c [cat1,cat2] -x [chainNum1,chainNum2]
    ```
 
    Options:
@@ -112,6 +81,12 @@ Currently, the CLI supports the following command:
    - `-e, --email <email>`: (required) Provide an email so we can contact you regarding the verification process
    - `-r, --repo <repoUrl>`: (required) To verify a plugin we need the url for a public repository containing the plugin's code
    - `-v, --version <versionNumber>`: (optional) Specify the version of the plugin in case of an update
+   - `-c, --categories <categories>`: (optional) List some categories that describe the type of plugin you're verifying.
+   - `-x, --chains <chainIds>`: (optional) If your plugin works on specific evm chains, you can specify them so your plugin is easier to find. 
+   
+   These options can also be defined in the agent spec in the `"x-mb"` object.
+   
+
 
 ## Development
 

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -19,17 +19,14 @@ export const deleteCommand = new Command()
 
     const pluginId = getHostname(url);
     const specUrl = getSpecUrl(url);
-    const { isValid, accountId } = await validateAndParseOpenApiSpec(specUrl);
+    const xMbSpec = await validateAndParseOpenApiSpec(specUrl);
 
-    if (!isValid) {
+    if (!xMbSpec) {
       console.error("OpenAPI specification validation failed.");
       return;
     }
+    const accountId = xMbSpec["account-id"];
 
-    if (!accountId) {
-      console.error("Failed to parse account ID from OpenAPI specification.");
-      return;
-    }
     const pluginService = new PluginService();
     const authentication = await pluginService.auth.getAuthentication();
     if (!authentication) {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -21,17 +21,13 @@ export const deployCommand = new Command()
 
     const id = getHostname(url);
     const specUrl = getSpecUrl(url);
-    const { isValid, accountId } = await validateAndParseOpenApiSpec(specUrl);
-
-    if (!isValid) {
+    const xMbSpec = await validateAndParseOpenApiSpec(specUrl);
+    if (!xMbSpec) {
       console.error("OpenAPI specification validation failed.");
       return;
     }
+    const accountId = xMbSpec["account-id"];
 
-    if (!accountId) {
-      console.error("Failed to parse account ID from OpenAPI specification.");
-      return;
-    }
     const pluginService = new PluginService();
     try {
       const updateRes = await pluginService.update(id);

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 
+import type { VerifyData, XMbSpec } from "../config/types";
 import { PluginService } from "../services/plugin";
 import { deployedUrl } from "../utils/deployed-url";
 import { validateAndParseOpenApiSpec } from "../utils/openapi";
@@ -8,12 +9,12 @@ import { getHostname, getSpecUrl } from "../utils/url-utils";
 export const verifyCommand = new Command()
   .name("verify")
   .description("Request verification of your deployed AI agent plugin")
-  .requiredOption("-u, --url <url>", "Specify the url of the deployed plugin")
-  .requiredOption(
+  .option("-u, --url <url>", "Specify the url of the deployed plugin")
+  .option(
     "-e, --email <email>",
     "Provide an email so we can contact you regarding the verification process",
   )
-  .requiredOption(
+  .option(
     "-r, --repo <repoUrl>",
     "To verify a plugin we need the url for a public repository containing the plugin's code",
   )
@@ -51,24 +52,44 @@ export const verifyCommand = new Command()
 
     const pluginId = getHostname(url);
     const specUrl = getSpecUrl(url);
-    const { isValid, accountId } = await validateAndParseOpenApiSpec(specUrl);
-
-    if (!isValid) {
+    const xMbSpec = await validateAndParseOpenApiSpec(specUrl);
+    if (!xMbSpec) {
       console.error("OpenAPI specification validation failed.");
       return;
     }
 
-    if (!accountId) {
-      console.error("Failed to parse account ID from OpenAPI specification.");
-      return;
-    }
+    try {
+      const agentData = formVerifyData(options, xMbSpec);
 
-    await new PluginService().verify({
-      pluginId,
-      email: options.email,
-      repo: options.repo,
-      version: options.version,
-      categories: options.categories,
-      chains: options.chains,
-    });
+      await new PluginService().verify({
+        pluginId,
+        ...agentData,
+      });
+    } catch (error) {
+      console.error(`Failed to send verification request: ${error}`);
+    }
   });
+
+function formVerifyData(options: unknown, spec: XMbSpec): VerifyData {
+  const verifyData: VerifyData = {
+    accountId: spec["account-id"],
+    email:
+      ((options as { email?: string }).email ?? spec.email) ||
+      (() => {
+        throw new Error("Email is required");
+      })(),
+    repo:
+      ((options as { repo?: string }).repo ?? spec.assistant.repo) ||
+      (() => {
+        throw new Error("Repository URL is required");
+      })(),
+    version:
+      (options as { version?: string }).version ?? spec.assistant.version,
+    categories:
+      (options as { categories?: string[] }).categories ??
+      spec.assistant.categories,
+    chainIds:
+      (options as { chains?: number[] }).chains ?? spec.assistant.chainIds,
+  };
+  return verifyData;
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,0 +1,102 @@
+export type XMbSpec = {
+  "account-id": string;
+  assistant: {
+    name: string;
+    description: string;
+    instructions: string;
+    tools?: XMbSpecTools[];
+    chainIds?: number[];
+    categories?: string[];
+    version?: string;
+    repo?: string;
+  };
+  email?: string;
+};
+
+type XMbSpecTools = {
+  type: string;
+};
+
+export type VerifyData = {
+  accountId: string;
+  email: string;
+  repo: string;
+  version?: string;
+  categories?: string[];
+  chainIds?: number[];
+};
+
+export function validateXMbSpec(xMbSpec: unknown): asserts xMbSpec is XMbSpec {
+  if (!xMbSpec || typeof xMbSpec !== "object") {
+    throw new Error("x-mb spec must be an object");
+  }
+
+  const spec = xMbSpec as Record<string, unknown>;
+
+  // Validate required fields
+  if (!spec["account-id"] || typeof spec["account-id"] !== "string") {
+    throw new Error("x-mb spec must contain account-id as string");
+  }
+
+  if (!spec.assistant || typeof spec.assistant !== "object") {
+    throw new Error("x-mb spec must contain assistant object");
+  }
+
+  const assistant = spec.assistant as Record<string, unknown>;
+
+  // Validate required assistant fields
+  const requiredStringFields = ["name", "description", "instructions"] as const;
+  for (const field of requiredStringFields) {
+    if (!assistant[field] || typeof assistant[field] !== "string") {
+      throw new Error(`assistant must contain ${field} as string`);
+    }
+  }
+
+  // Validate optional fields
+  if (assistant.tools !== undefined) {
+    if (!Array.isArray(assistant.tools)) {
+      throw new Error("tools must be an array");
+    }
+    for (const tool of assistant.tools) {
+      if (!tool || typeof tool !== "object") {
+        throw new Error("each tool must be an object");
+      }
+      if (!("type" in tool) || typeof tool.type !== "string") {
+        throw new Error("each tool must have a type string");
+      }
+    }
+  }
+
+  if (assistant.chainIds !== undefined) {
+    if (
+      !Array.isArray(assistant.chainIds) ||
+      !assistant.chainIds.every((id) => typeof id === "number")
+    ) {
+      throw new Error("chainIds must be an array of numbers");
+    }
+  }
+
+  if (assistant.categories !== undefined) {
+    if (
+      !Array.isArray(assistant.categories) ||
+      !assistant.categories.every((cat) => typeof cat === "string")
+    ) {
+      throw new Error("categories must be an array of strings");
+    }
+  }
+
+  // Validate optional string fields
+  const optionalStringFields = ["version", "repo"] as const;
+  for (const field of optionalStringFields) {
+    if (
+      assistant[field] !== undefined &&
+      typeof assistant[field] !== "string"
+    ) {
+      throw new Error(`${field} must be a string`);
+    }
+  }
+
+  if (spec.email !== undefined && typeof spec.email !== "string") {
+    throw new Error("email must be a string");
+  }
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -26,20 +26,16 @@ export type VerifyData = {
   chainIds?: number[];
 };
 
-export function validateXMbSpec(xMbSpec: unknown): asserts xMbSpec is XMbSpec {
+export function isXMbSpec(xMbSpec: unknown): xMbSpec is XMbSpec {
   if (!xMbSpec || typeof xMbSpec !== "object") {
-    throw new Error("x-mb spec must be an object");
+    return false;
   }
 
   const spec = xMbSpec as Record<string, unknown>;
 
   // Validate required fields
-  if (!spec["account-id"] || typeof spec["account-id"] !== "string") {
-    throw new Error("x-mb spec must contain account-id as string");
-  }
-
   if (!spec.assistant || typeof spec.assistant !== "object") {
-    throw new Error("x-mb spec must contain assistant object");
+    return false;
   }
 
   const assistant = spec.assistant as Record<string, unknown>;
@@ -48,21 +44,21 @@ export function validateXMbSpec(xMbSpec: unknown): asserts xMbSpec is XMbSpec {
   const requiredStringFields = ["name", "description", "instructions"] as const;
   for (const field of requiredStringFields) {
     if (!assistant[field] || typeof assistant[field] !== "string") {
-      throw new Error(`assistant must contain ${field} as string`);
+      return false;
     }
   }
 
   // Validate optional fields
   if (assistant.tools !== undefined) {
     if (!Array.isArray(assistant.tools)) {
-      throw new Error("tools must be an array");
+      return false;
     }
     for (const tool of assistant.tools) {
       if (!tool || typeof tool !== "object") {
-        throw new Error("each tool must be an object");
+        return false;
       }
       if (!("type" in tool) || typeof tool.type !== "string") {
-        throw new Error("each tool must have a type string");
+        return false;
       }
     }
   }
@@ -72,7 +68,7 @@ export function validateXMbSpec(xMbSpec: unknown): asserts xMbSpec is XMbSpec {
       !Array.isArray(assistant.chainIds) ||
       !assistant.chainIds.every((id) => typeof id === "number")
     ) {
-      throw new Error("chainIds must be an array of numbers");
+      return false;
     }
   }
 
@@ -81,7 +77,7 @@ export function validateXMbSpec(xMbSpec: unknown): asserts xMbSpec is XMbSpec {
       !Array.isArray(assistant.categories) ||
       !assistant.categories.every((cat) => typeof cat === "string")
     ) {
-      throw new Error("categories must be an array of strings");
+      return false;
     }
   }
 
@@ -92,11 +88,13 @@ export function validateXMbSpec(xMbSpec: unknown): asserts xMbSpec is XMbSpec {
       assistant[field] !== undefined &&
       typeof assistant[field] !== "string"
     ) {
-      throw new Error(`${field} must be a string`);
+      return false;
     }
   }
 
   if (spec.email !== undefined && typeof spec.email !== "string") {
-    throw new Error("email must be a string");
+    return false;
   }
+
+  return true;
 }

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -179,7 +179,6 @@ export class TunnelService {
       console.error("OpenAPI specification validation failed.");
       return;
     }
-    const accountId = xMbSpec["account-id"];
 
     const result = await this.pluginService.register({
       pluginId: this.pluginId,

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -174,11 +174,12 @@ export class TunnelService {
     }
 
     const specUrl = getSpecUrl(this.tunnelUrl);
-    const { isValid } = await validateAndParseOpenApiSpec(specUrl);
-
-    if (!isValid) {
-      throw new Error("OpenAPI specification validation failed.");
+    const xMbSpec = await validateAndParseOpenApiSpec(specUrl);
+    if (!xMbSpec) {
+      console.error("OpenAPI specification validation failed.");
+      return;
     }
+    const accountId = xMbSpec["account-id"];
 
     const result = await this.pluginService.register({
       pluginId: this.pluginId,

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -1,6 +1,6 @@
 import SwaggerParser from "@apidevtools/swagger-parser";
 
-import { validateXMbSpec, type XMbSpec } from "../config/types";
+import { isXMbSpec, type XMbSpec } from "../config/types";
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 1000;
@@ -21,7 +21,7 @@ export async function validateAndParseOpenApiSpec(
         "Failed to parse OpenAPI spec JSON:",
         error instanceof Error ? error.message : "Unknown error",
       );
-      return { isValid: false };
+      return undefined;
     }
 
     try {
@@ -47,11 +47,11 @@ export async function validateAndParseOpenApiSpec(
           );
         }
       }
-      return { isValid: false };
+      return undefined;
     }
 
     const xMbSpec = apiResponse["x-mb"];
-    validateXMbSpec(xMbSpec);
+    isXMbSpec(xMbSpec);
 
     return xMbSpec;
   } catch (error) {

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -1,12 +1,14 @@
 import SwaggerParser from "@apidevtools/swagger-parser";
 
+import { validateXMbSpec, type XMbSpec } from "../config/types";
+
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 1000;
 
 //parsing and validation done together to avoid fetching spec twice
 export async function validateAndParseOpenApiSpec(
   url: string | URL,
-): Promise<{ isValid: boolean; accountId?: string }> {
+): Promise<XMbSpec | undefined> {
   try {
     const specUrl = url.toString();
     const specContent = await fetchWithRetry(specUrl);
@@ -48,14 +50,16 @@ export async function validateAndParseOpenApiSpec(
       return { isValid: false };
     }
 
-    const accountId = apiResponse["x-mb"]?.["account-id"];
-    return { isValid: true, accountId: accountId };
-  } catch (error: unknown) {
+    const xMbSpec = apiResponse["x-mb"];
+    validateXMbSpec(xMbSpec);
+
+    return xMbSpec;
+  } catch (error) {
     console.error(
       "Unexpected error:",
       error instanceof Error ? error.message : "Unknown error",
     );
-    return { isValid: false };
+    return undefined;
   }
 }
 


### PR DESCRIPTION
- A new type has been created to represent the data in `x-mb` from the manifest.
- Verify data can now be added to `x-mb` instead of being passed through flags on the command line