### PR TITLE
log message for port detection during tunneling setup

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -12,6 +12,7 @@ export const devCommand = new Command()
   .action(async (options) => {
     let port = options.port;
     if (!port) {
+      console.log('Port not specified. Attempting to detect an app port for tunneling...');
       port = await detectPort();
       if (!port) {
         console.error(


### PR DESCRIPTION
if detectPort taking too long, it is not clear why command is not going forward, so this message would make it clear what is going on