### PR TITLE
Testing Part 1: Hash Payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
-    "borsh": "^0.7.0",
+    "borsh": "^2.0.0",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.1(openapi-types@12.1.3)
       borsh:
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^2.0.0
+        version: 2.0.0
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -1168,24 +1168,18 @@ packages:
     engines: {node: '>=4.5.0'}
     deprecated: use 3.0.0 instead, safe-buffer has been merged and release for compatability
 
-  base-x@3.0.10:
-    resolution: {integrity: sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==}
-
   bn.js@4.12.1:
     resolution: {integrity: sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==}
-
-  bn.js@5.2.1:
-    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  borsh@0.7.0:
-    resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
-
   borsh@1.0.0:
     resolution: {integrity: sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==}
+
+  borsh@2.0.0:
+    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1202,9 +1196,6 @@ packages:
 
   bs58@4.0.0:
     resolution: {integrity: sha512-/jcGuUuSebyxwLLfKrbKnCJttxRf9PM51EnHTwmFKBxl4z1SGkoAhrfd6uZKE0dcjQTfm6XzTP8DPr1tzE4KIw==}
-
-  bs58@4.0.1:
-    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -2558,9 +2549,6 @@ packages:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
 
-  text-encoding-utf-8@1.0.2:
-    resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
-
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -3806,13 +3794,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  base-x@3.0.10:
-    dependencies:
-      safe-buffer: 5.2.1
-
   bn.js@4.12.1: {}
-
-  bn.js@5.2.1: {}
 
   body-parser@1.20.3:
     dependencies:
@@ -3831,13 +3813,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  borsh@0.7.0:
-    dependencies:
-      bn.js: 5.2.1
-      bs58: 4.0.1
-      text-encoding-utf-8: 1.0.2
-
   borsh@1.0.0: {}
+
+  borsh@2.0.0: {}
 
   brace-expansion@1.1.11:
     dependencies:
@@ -3857,10 +3835,6 @@ snapshots:
   bs58@4.0.0:
     dependencies:
       base-x: 2.0.6
-
-  bs58@4.0.1:
-    dependencies:
-      base-x: 3.0.10
 
   bundle-name@4.1.0:
     dependencies:
@@ -5410,8 +5384,6 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 10.4.5
       minimatch: 9.0.5
-
-  text-encoding-utf-8@1.0.2: {}
 
   thenify-all@1.6.0:
     dependencies:

--- a/src/services/authentication.ts
+++ b/src/services/authentication.ts
@@ -98,7 +98,7 @@ export class AuthenticationService {
         return null;
       }
 
-      const isVerified = await verifyMessage({ params: signedMessage });
+      const isVerified = verifyMessage({ params: signedMessage });
       if (!isVerified) {
         console.warn("Message verification failed");
       }

--- a/src/utils/verify-msg-utils.ts
+++ b/src/utils/verify-msg-utils.ts
@@ -12,13 +12,13 @@ export interface KeySignMessageParams {
   accountId?: string;
 }
 
-export const verifyMessage = async ({
+export const verifyMessage = ({
   params,
   accountIdToVerify,
 }: {
   params: KeySignMessageParams;
   accountIdToVerify?: string;
-}): Promise<boolean> => {
+}): boolean => {
   const {
     message,
     nonce,

--- a/src/utils/verify-msg-utils.ts
+++ b/src/utils/verify-msg-utils.ts
@@ -103,17 +103,11 @@ export class Payload {
   }
 }
 
-const payloadSchema = new Map([
-  [
-    Payload,
-    {
-      kind: "struct",
-      fields: [
-        ["message", "string"],
-        ["nonce", [32]],
-        ["recipient", "string"],
-        ["callbackUrl", { kind: "option", type: "string" }],
-      ],
-    },
-  ],
-]);
+const payloadSchema = {
+  struct: {
+    message: "string",
+    nonce: { array: { type: "u8", len: 32 } },
+    recipient: "string",
+    callbackUrl: { option: "string" },
+  },
+};

--- a/tests/verify-msg-utils.spec.ts
+++ b/tests/verify-msg-utils.spec.ts
@@ -1,4 +1,3 @@
-import { KeyPair } from "near-api-js";
 import { describe, it, expect } from "vitest";
 
 import {
@@ -29,10 +28,9 @@ describe("verifyMessage", () => {
     accountId: "sender.near",
     callbackUrl: payload.callbackUrl,
   };
-  console.log(mockParams);
 
-  it("should return false when accountIdToVerify does not match accountId", async () => {
-    const result = await verifyMessage({
+  it("should return false when accountIdToVerify does not match accountId", () => {
+    const result = verifyMessage({
       params: mockParams,
       accountIdToVerify: "different.near",
     });
@@ -40,8 +38,8 @@ describe("verifyMessage", () => {
     expect(result).toBe(false);
   });
 
-  it("should verify signature when accountIds match", async () => {
-    const result = await verifyMessage({
+  it("should verify signature when accountIds match", () => {
+    const result = verifyMessage({
       params: mockParams,
       accountIdToVerify: "sender.near",
     });
@@ -50,22 +48,40 @@ describe("verifyMessage", () => {
   });
 
   it("should verify signature when no accountIdToVerify is provided", async () => {
-    const result = await verifyMessage({
+    const result = verifyMessage({
       params: mockParams,
     });
 
     expect(result).toBe(true);
   });
 
-  it("should return false with invalid signature", async () => {
-    const invalidSignature = signature.replace("0", "1");
-    const result = await verifyMessage({
+  it("should return false with invalid signature", () => {
+    const result = verifyMessage({
       params: {
         ...mockParams,
-        signature: invalidSignature,
+        // Invalid signature
+        signature: signature.replace("0", "1"),
       },
     });
 
     expect(result).toBe(false);
+  });
+});
+
+describe("hashPayload", () => {
+  it("should deterministically hash the same payload", () => {
+    const payload = new Payload({
+      message: "Hello World",
+      nonce: "base64EncodedNonce==",
+      recipient: "recipient.near",
+      callbackUrl: "https://example.com/callback",
+    });
+    const result = hashPayload(payload);
+    expect(result).toStrictEqual(new Uint8Array([
+      121,  19,   8,  79, 179,  10, 206,   2,
+      107,   0, 134,  57,  44, 188, 164, 233,
+      148, 144, 233, 129, 124, 106, 220, 166,
+      102,  71, 171, 204, 149, 213,  42,  54
+    ]));
   });
 });

--- a/tests/verify-msg-utils.spec.ts
+++ b/tests/verify-msg-utils.spec.ts
@@ -77,11 +77,12 @@ describe("hashPayload", () => {
       callbackUrl: "https://example.com/callback",
     });
     const result = hashPayload(payload);
-    expect(result).toStrictEqual(new Uint8Array([
-      121,  19,   8,  79, 179,  10, 206,   2,
-      107,   0, 134,  57,  44, 188, 164, 233,
-      148, 144, 233, 129, 124, 106, 220, 166,
-      102,  71, 171, 204, 149, 213,  42,  54
-    ]));
+    expect(result).toStrictEqual(
+      new Uint8Array([
+        121, 19, 8, 79, 179, 10, 206, 2, 107, 0, 134, 57, 44, 188, 164, 233,
+        148, 144, 233, 129, 124, 106, 220, 166, 102, 71, 171, 204, 149, 213, 42,
+        54,
+      ]),
+    );
   });
 });


### PR DESCRIPTION
Here, we notice that some async functions did not need to be async... Was there any special reason for this? We also add a test for `hashPayload` (the only part of the project using borsh). This will allow us to upgrade the borsh dependency safely and with confidence.

1. The first commit adds a test for all places we use borsh.
2. Second commit upgrades borsh and demonstrates the tests still pass.
