### PR TITLE
Bug: Spec Validation in dev Command

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -26,7 +26,6 @@ export const deployCommand = new Command()
       console.error("OpenAPI specification validation failed.");
       return;
     }
-    const accountId = xMbSpec["account-id"];
 
     const pluginService = new PluginService();
     try {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -52,7 +52,11 @@ async function fetchAndValidateSpec(url: string): Promise<ValidationResult> {
   try {
     console.log("[Dev] Validating OpenAPI spec...");
     const validation = await validateAndParseOpenApiSpec(specUrl);
-    ({ isValid, accountId } = validation);
+    if (!validation) {
+      throw new Error("Invalid OpenAPI spec");
+    }
+    isValid = true;
+    accountId = validation["account-id"];
     console.log("[Dev] Validation result:", { isValid, accountId });
   } catch (error) {
     console.error(

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -8,9 +8,9 @@ import open from "open";
 
 import { PluginService } from "./plugin";
 import { BITTE_CONFIG_ENV_KEY } from "../config/constants";
-import { appendToEnv, removeFromEnv } from "../utils/file-utils";
+import { appendToEnv, removeFromEnv } from "../utils/file";
 import { validateAndParseOpenApiSpec } from "../utils/openapi";
-import { getSpecUrl } from "../utils/url-utils";
+import { getSpecUrl } from "../utils/url";
 
 interface BitteConfig {
   url?: string;

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -8,9 +8,9 @@ import open from "open";
 
 import { PluginService } from "./plugin";
 import { BITTE_CONFIG_ENV_KEY } from "../config/constants";
-import { appendToEnv, removeFromEnv } from "../utils/file";
+import { appendToEnv, removeFromEnv } from "../utils/file-utils";
 import { validateAndParseOpenApiSpec } from "../utils/openapi";
-import { getSpecUrl } from "../utils/url";
+import { getSpecUrl } from "../utils/url-utils";
 
 interface BitteConfig {
   url?: string;

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -51,9 +51,10 @@ export async function validateAndParseOpenApiSpec(
     }
 
     const xMbSpec = apiResponse["x-mb"];
-    isXMbSpec(xMbSpec);
-
-    return xMbSpec;
+    if (isXMbSpec(xMbSpec)) {
+      return xMbSpec;
+    }
+    throw new Error("Invalid OpenAPI spec");
   } catch (error) {
     console.error(
       "Unexpected error:",


### PR DESCRIPTION
A recent PR (#37) introduced OpenAPI Spec Validation, but it was not aligned with the dev command code (attempting to access undefined object fields). There were also some other obvious bugs fixed here.