### PR TITLE
Re-add ajv-draft-04

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@typescript-eslint/parser": "^8.23.0",
     "@vitest/coverage-v8": "^3.0.5",
     "ajv": "^8.17.1",
+    "ajv-draft-04": "^1.0.0",
     "eslint": "^9.15.0",
     "eslint-plugin-import": "^2.31.0",
     "prettier": "^3.4.2",
@@ -65,7 +66,7 @@
     "tsx": "^4.7.1",
     "typescript": "^5.7.3",
     "vitest": "^3.0.5"
-  }, 
+  },
   "overrides": {
     "secp256k1": ">=5.0.1",
     "elliptic": ">=6.6.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      ajv-draft-04:
+        specifier: ^1.0.0
+        version: 1.0.0(ajv@8.17.1)
       eslint:
         specifier: ^9.15.0
         version: 9.19.0(jiti@2.4.2)


### PR DESCRIPTION
There seems to be some unusual import error that end users get without this package. I have proposed a potential solution in the dependency repo: https://github.com/APIDevTools/swagger-parser/pull/268

In the meantime, we just put this back here.