### PR TITLE
Fix: Finally eliminate ajv error & Log url to user on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Currently, the CLI supports the following command:
    - `-u, --url <url>`: The URL where your agent is hosted (optional)
 
    If no URL is provided, the command will attempt to determine the URL automatically through environment variables.
+   In particular, see [deployed-url.ts](src/utils/deployed-url.ts) for various deployment configurations.
 
 1. ### **`contract`**: Scaffold a basic agent from a NEAR contract that has an ABI
    Usage:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   "license": "MIT",
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
+    "ajv": "^8.17.1",
+    "ajv-draft-04": "^1.0.0",
     "borsh": "^2.0.0",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
@@ -57,8 +59,6 @@
     "@typescript-eslint/eslint-plugin": "^8.15.0",
     "@typescript-eslint/parser": "^8.23.0",
     "@vitest/coverage-v8": "^3.0.5",
-    "ajv": "^8.17.1",
-    "ajv-draft-04": "^1.0.0",
     "eslint": "^9.15.0",
     "eslint-plugin-import": "^2.31.0",
     "prettier": "^3.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@apidevtools/swagger-parser':
         specifier: ^10.1.0
         version: 10.1.1(openapi-types@12.1.3)
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      ajv-draft-04:
+        specifier: ^1.0.0
+        version: 1.0.0(ajv@8.17.1)
       borsh:
         specifier: ^2.0.0
         version: 2.0.0
@@ -66,12 +72,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.0.5
         version: 3.0.5(vitest@3.0.5(@types/node@22.13.1))
-      ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
-      ajv-draft-04:
-        specifier: ^1.0.0
-        version: 1.0.0(ajv@8.17.1)
       eslint:
         specifier: ^9.15.0
         version: 9.19.0(jiti@2.4.2)

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -17,6 +17,8 @@ export const deployCommand = new Command()
     if (!url) {
       console.error("Deployed URL could not be determined.");
       return;
+    } else {
+      console.log("Using deployment URL:", url);
     }
 
     const id = getHostname(url);


### PR DESCRIPTION
We move the ajv dependencies out of dev deps. This actually resolves the issue.

running make-agent deploy without the [optional] url argument results in the following:

```
➜  wraptor git:(upgrade) ✗ npx make-agent deploy
Retrying...
Retrying...
Retrying...
Unexpected error: fetch failed
OpenAPI specification validation failed.
```

Digging into the code it seems that the env vars are not loaded. There is also no documentation about what env vars should be set if the URL is not supplied in the runtime argument.


Closes #77 