### PR TITLE
Branch release skip main

### DIFF
--- a/.github/workflows/branch-release.yaml
+++ b/.github/workflows/branch-release.yaml
@@ -1,7 +1,10 @@
 name: Branch Release
 
 on:
-  push
+  push:
+    branches:
+      - '**'
+      - '!main'
 
 jobs:
   branch-release:

--- a/.github/workflows/branch-release.yaml
+++ b/.github/workflows/branch-release.yaml
@@ -67,7 +67,6 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
 
       - name: Publish with npm
-        if: ${{ github.ref_name != 'main' }}
         run: npm publish --access public --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Branch releases were running on main (checkout, install build, prepare, etc) until the very last line where if not main branch publish.

This should exclude the entire run for main branch (save some unnecessary resource waste).