### PR TITLE
Remove Duplicate Command Setup Code

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,9 +1,7 @@
 import { Command } from "commander";
 
+import { setup } from "./setup.ts";
 import { PluginService } from "../services/plugin";
-import { deployedUrl } from "../utils/deployed-url";
-import { validateAndParseOpenApiSpec } from "../utils/openapi";
-import { getSpecUrl, getHostname } from "../utils/url";
 
 export const deployCommand = new Command()
   .name("deploy")
@@ -12,33 +10,16 @@ export const deployCommand = new Command()
   )
   .option("-u, --url <url>", "Specify the deployment URL")
   .action(async (options) => {
-    const url = options.url || deployedUrl;
-
-    if (!url) {
-      console.error("Deployed URL could not be determined.");
-      return;
-    } else {
-      console.log("Using deployment URL:", url);
-    }
-
-    const id = getHostname(url);
-    const specUrl = getSpecUrl(url);
-    const xMbSpec = await validateAndParseOpenApiSpec(specUrl);
-    if (!xMbSpec) {
-      console.error("OpenAPI specification validation failed.");
-      return;
-    }
+    const { pluginId } = await setup(options.url);
 
     const pluginService = new PluginService();
     try {
-      const updateRes = await pluginService.update(id);
+      const updateRes = await pluginService.update(pluginId);
       if (!updateRes) {
         console.log("Attempting to register plugin...");
-        await pluginService.register({
-          pluginId: id,
-        });
+        await pluginService.register({ pluginId });
       }
     } catch (error) {
-      console.error(`Failed to deploy plugin ${id}. Error: ${error}`);
+      console.error(`Failed to deploy plugin ${pluginId}. Error: ${error}`);
     }
   });

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,0 +1,22 @@
+import type { XMbSpec } from "../config/types.ts";
+import { deployedUrl } from "../utils/deployed-url.ts";
+import { validateAndParseOpenApiSpec } from "../utils/openapi.ts";
+import { getHostname, getSpecUrl } from "../utils/url.ts";
+
+export async function setup(
+  optionsUrl?: string,
+): Promise<{ pluginId: string; xMbSpec: XMbSpec }> {
+  const url = optionsUrl || deployedUrl;
+
+  if (!url) {
+    throw new Error("Deployed URL could not be determined.");
+  }
+
+  const pluginId = getHostname(url);
+  const specUrl = getSpecUrl(url);
+  const xMbSpec = await validateAndParseOpenApiSpec(specUrl);
+  if (!xMbSpec) {
+    throw new Error("OpenAPI specification validation failed.");
+  }
+  return { pluginId, xMbSpec };
+}

--- a/tests/utils/deployed-url.spec.ts
+++ b/tests/utils/deployed-url.spec.ts
@@ -118,10 +118,6 @@ describe("deployed-url utilities", () => {
       "should return $name URL when in $name environment",
       ({ env, expected }) => {
         Object.assign(process.env, env);
-        console.log("process.env", process.env.VERCEL_ENV);
-        console.log("process.env", env);
-        console.log("expected", expected);
-        console.log("getDeployedUrl", getDeployedUrl());
         expect(getDeployedUrl()).toBe(expected);
       },
     );


### PR DESCRIPTION
Introducing a setup function that is used by most (non-deprecated) commands.

We also remove some unnecessary console logs from tests.