### PR TITLE
Propose Softer Logging on First Deploy

### DIFF
--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -49,7 +49,12 @@ export class PluginService {
     });
 
     if (!response.ok) {
-      console.error(`Failed to update plugin: ${await response.text()}`);
+      const responseText = await response.text();
+      if (responseText.includes("Plugin not found")) {
+        console.warn(`Plugin with ID ${pluginId} not found/registered.`);
+      } else {
+        console.error("Failed to update plugin", responseText);
+      }
       return null;
     }
 


### PR DESCRIPTION
On first deploy, there were some weird error logs that didn't make much sense:


# Before
```
$ export AGENT_URL=somestuff.com
$ npx make-agent deploy -u $AGENT_URL
OpenAPI specification is valid.
[ERROR] Failed to update plugin: {"error":"Plugin not found. Please register the plugin first."}
Attempting to register plugin...
Plugin registered successfully

$ npx make-agent deploy -u $AGENT_URL
OpenAPI specification is valid.
Plugin updated successfully.
```

# After

Logs should look like
```
OpenAPI specification is valid.
[WARN] Plugin with ID ${pluginId} not found/registered.
Attempting to register plugin...
Plugin registered successfully
```

