### PR TITLE
fix: use static historyApiUrl

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -30,5 +30,6 @@ export const SIGN_MESSAGE_PORT = 6969;
 export const SIGN_MESSAGE = "Register Bitte Agent!";
 export const BITTE_CONFIG_ENV_KEY = "BITTE_CONFIG";
 export const BITTE_KEY_ENV_KEY = "BITTE_KEY";
+export const BITTE_HISTORY_API_URL = "https://api.bitte.ai/v1/history";
 
 export const DEFAULT_PORT = 3000;

--- a/src/services/server.ts
+++ b/src/services/server.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 
 import { type ApiConfig } from "../commands/dev";
+import { BITTE_HISTORY_API_URL } from "../config/constants";
 
 export async function startUIServer(
   apiConfig: ApiConfig,
@@ -93,7 +94,7 @@ export async function startUIServer(
       if (!id) {
         throw new Error("No history id on request.");
       }
-      const url = `${apiConfig.url}/history?id=${id}`;
+      const url = `${BITTE_HISTORY_API_URL}?id=${id}`;
 
       const response = await fetch(url, {
         headers: {


### PR DESCRIPTION
History endpoint should be static and not using the ai runtime which doesn't support history yet.